### PR TITLE
added: new params for customize colors of the page in the iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
       <p class="made-by">Made with <a href="https://niftycase.io" target="_blank">Niftycase</a></p>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="js/custom_regexp.js"></script>
     <script src="js/nft_scroller.js"></script>
     <script src="js/nft_slider.js"></script>
     <script type="text/javascript">
@@ -48,6 +49,8 @@
 
           const urlSearchParams = new URLSearchParams(window.location.search);
           const params = Object.fromEntries(urlSearchParams.entries());
+
+          console.log(params);
           if (params.view && parseInt(params.view) === 2) {
 
             $('head').append('<link rel="stylesheet" href="css/nft_scroller.css" />');
@@ -78,6 +81,16 @@
               }
             });
 
+          }
+
+          const bgColor = !params.bg_color ? false : color_regexp.test(params.bg_color) ? params.bg_color : false;
+
+          if (bgColor) {
+            const $nftSlider = document.querySelector(".nft-slider");
+
+            $nftSlider.style.background = `#${bgColor}`
+            document.body.style.background = `#${bgColor}`
+            
           }
 
         });

--- a/js/custom_regexp.js
+++ b/js/custom_regexp.js
@@ -1,0 +1,1 @@
+const color_regexp = new RegExp(/^([ABCDEFabcdef0-9]{3}|[ABCDEFabcdef0-9]{6})$/);

--- a/js/nft_scroller.js
+++ b/js/nft_scroller.js
@@ -9,11 +9,14 @@
     }).join('&');
   }
 
-  if (window.location.href.indexOf("dm") > -1) {
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const params = Object.fromEntries(urlSearchParams.entries());
+
+  if ((params.eth_icon && params.eth_icon === "1") || window.location.href.indexOf("dm") > -1) {
     document.getElementById("eth-logo").src = "media/eth2.png"
   }
 
-  if (window.location.href.indexOf("dark") > -1) {
+  if ((params.eth_icon && params.eth_icon === "2") || window.location.href.indexOf("dark") > -1) {
     console.log("eeeee")
     document.getElementById("eth-logo").src = "media/eth.png"
   }
@@ -28,24 +31,27 @@
     let opts = $.extend({}, $.fn.nftScroller.defaults, options);
 
     if (!opts.target) {
-      const urlSearchParams = new URLSearchParams(window.location.search);
-      const params = Object.fromEntries(urlSearchParams.entries());
       opts = $.extend({}, params, { addr: this.attr('data-addr') }, opts);
     }
+
+    const cardColor = !params.bg_card ? false : color_regexp.test(params.bg_card) ? params.bg_card : false
+    const collectionNameColor = !params.collection_name_color ? false : color_regexp.test(params.collection_name_color) ? params.collection_name_color : false
+    const assetNameColor = !params.asset_name_color ? false : color_regexp.test(params.asset_name_color) ? params.asset_name_color : false;
+    const addrColor = !params.addr_color ? false : color_regexp.test(params.addr_color) ? params.addr_color : false
 
     let makeCards = function(assets) {
       let elem = $(self).find('.nft-content');
       assets.forEach((asset, i) => {
         elem.append($(`
-          <div class="nft-card">
+          <div class="nft-card" ${cardColor && `style="background: #${cardColor}"`}>
             <a href="${asset.permalink}" target="_blank">
               <div class="nft-card-img" style="background-image: url(${asset.image_url || asset.collection.image_url})"></div>
             </a>
             <section>
               <a href="https://opensea.io/collection/${asset.collection.slug}" target="_blank"><img src="${asset.collection.image_url || asset.image_url}" onerror="this.style.display='none'" /></a>
-              <a class="nft-card-title" href="https://opensea.io/collection/${asset.collection.slug}" target="_blank">${asset.collection.name || 'Untitled'}</a>
+              <a class="nft-card-title" href="https://opensea.io/collection/${asset.collection.slug}" target="_blank" ${collectionNameColor && `style="color: #${collectionNameColor}"`}>${asset.collection.name || 'Untitled'}</a>
             </section>
-            <a class="nft-card-subtitle" href="${asset.permalink}" target="_blank">${asset.name || "#" + asset.token_id || 'Untitled'}</a>
+            <a class="nft-card-subtitle" href="${asset.permalink}" target="_blank" ${assetNameColor && `style="color: #${assetNameColor}"`}>${asset.name || "#" + asset.token_id || 'Untitled'}</a>
           </div>
         `));
       });
@@ -55,7 +61,7 @@
       let path, node, addrElem = $(self).find('header div');
       path = addr.substring(0,Math.min(6, addr.length)) + '…' +
         addr.substring(addr.length - 4);
-      node = $(`<a href="http://opensea.io/${addr}" target="_blank">${path}</a>`)
+      node = $(`<a href="http://opensea.io/${addr}" target="_blank" ${addrColor && `style="color: #${addrColor} !important"`}>${path}</a>`)
         .addClass('eth-addr');
       addrElem.append(node);
     };
@@ -145,7 +151,7 @@
           if ((eventType == "successful") && (response.asset_events[i].winner_account.address != addr.toLowerCase())) {
             let eventType = "Sold";
             let tabs = $(`
-            <div>
+            ${!cardColor ? "<div>" : `<div style="background: #${cardColor}">`}
               <a href="${assetLink}" target="_blank" class="imageAnchor">
                 <div class="nft-card-img nftactivity-card-img" style="background-image: url(${assetImage || backupImage})"></div>
                 <p class="nameInsideImage">${assetName || colllectionName + " " + assetId}</p>
@@ -162,7 +168,7 @@
             let price = fixPrice(response.asset_events[i].ending_price);
             let paymentToken = getPaymentToken();
             let tabs = $(`
-              <div>
+              ${!cardColor ? "<div>" : `<div style="background: #${cardColor}">`}
                 <a href="${assetLink}" target="_blank" class="imageAnchor">
                   <div class="nft-card-img nftactivity-card-img" style="background-image: url(${assetImage || backupImage})"></div>
                   <p class="nameInsideImage">${assetName || colllectionName + " " + assetId}</p>
@@ -178,7 +184,7 @@
           if ((eventType == "transfer") && (response.asset_events[i].from_account.address != "0x0000000000000000000000000000000000000000") && (response.asset_events[i].asset.num_sales > 0) && (response.asset_events[i].to_account.address == addr.toLowerCase())){
             let eventType = "Purchased";
               let tabs = $(`
-              <div>
+              ${!cardColor ? "<div>" : `<div style="background: #${cardColor}">`}
                 <a href="${assetLink}" target="_blank" class="imageAnchor">
                   <div class="nft-card-img nftactivity-card-img" style="background-image: url(${assetImage || backupImage})"></div>
                   <p class="nameInsideImage">${assetName || colllectionName + " " + assetId}</p>
@@ -194,7 +200,7 @@
             if ((eventType == "transfer") && (response.asset_events[i].from_account.address == "0x0000000000000000000000000000000000000000") && (response.asset_events[i].transaction.from_account.address == response.asset_events[i].to_account.address) && (response.asset_events[i].to_account.address == addr.toLowerCase())){
               let eventType = "Minted";
                 let tabs = $(`
-                <div>
+                ${!cardColor ? "<div>" : `<div style="background: #${cardColor}">`}
                   <a href="${assetLink}" target="_blank" class="imageAnchor">
                     <div class="nft-card-img nftactivity-card-img" style="background-image: url(${assetImage || backupImage})"></div>
                     <p class="nameInsideImage">${assetName || colllectionName + " " + assetId}</p>

--- a/js/nft_slider.js
+++ b/js/nft_slider.js
@@ -21,17 +21,23 @@
     let curr = 0, count = 0, slides = [];
     let opts = $.extend({}, $.fn.nftSlider.defaults, options);
 
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const params = Object.fromEntries(urlSearchParams.entries());
+
     if (!opts.target) {
-      const urlSearchParams = new URLSearchParams(window.location.search);
-      const params = Object.fromEntries(urlSearchParams.entries());
       opts = $.extend({}, params, { addr: this.attr('data-addr') }, opts);
     }
+
+    const cardColor = !params.bg_card ? false : color_regexp.test(params.bg_card) ? params.bg_card : false
+    const collectionNameColor = !params.collection_name_color ? false : color_regexp.test(params.collection_name_color) ? params.collection_name_color : false
+    const assetNameColor = !params.asset_name_color ? false : color_regexp.test(params.asset_name_color) ? params.asset_name_color : false;
+    const addrColor = !params.addr_color ? false : color_regexp.test(params.addr_color) ? params.addr_color : false
 
     let makeETHAdress = function(addr) {
       let path, node, addrElem = $(self).find('header div');
       path = addr.substring(0,Math.min(6, addr.length)) + '…' +
         addr.substring(addr.length - 4);
-      node = $(`<a href="http://opensea.io/${addr}" target="_blank">${path}</a>`)
+      node = $(`<a href="http://opensea.io/${addr}" target="_blank" ${addrColor && `style="color: #${addrColor}"`}>${path}</a>`)
         .addClass('eth-addr');
       addrElem.append(node);
     }
@@ -39,7 +45,7 @@
     let makeNavigation = function(count) {
       let btn, navElem = $(self).find('nav');
 
-      btn = $('<a>←</a>')
+      btn = $(`<a>←</a>`)
         .attr('id', 'btn-prev')
         .click(onPrev);
       navElem.append(btn);
@@ -54,7 +60,7 @@
         navElem.append(btn);
       }
 
-      btn = $('<a>→</a>')
+      btn = $(`<a>→</a>`)
         .attr('id', 'btn-next')
         .click(onNext);
       navElem.append(btn);
@@ -69,16 +75,16 @@
           let asset_name = asset.name || 'Untitled';
           let collection_name = asset.collection.name || 'Untitled';
 
-          return `<div>
+          return `${!cardColor ? "<div>" : `<div style="background: #${cardColor}">`}
               <a href="${asset.permalink}" target="_blank">
                 <div class="nft-card-img" style="background-image: url(${asset.image_url || ''});"></div>
               </a>
               <p class="collection-name">
                 <img src="${asset.collection.image_url || ''}" onerror="this.style.display='none'" />
-                <a href="https://opensea.io/${asset.collection.slug}">${collection_name}</a>
+                <a href="https://opensea.io/${asset.collection.slug}" ${collectionNameColor && `style="color: #${collectionNameColor}"`}>${collection_name}</a>
               </p>
               <p class="asset-name">
-                <a href="${asset.permalink}" target="_blank">${asset_name}</a>
+                <a href="${asset.permalink}" target="_blank" ${assetNameColor && `style="color: #${assetNameColor}"`}>${asset_name}</a>
               </p>
             </div>`;
         }).join('');
@@ -104,9 +110,9 @@
     let onNext = function(event) {
       curr = (curr + 1) % count;
 
-      $(self).find('.active').toggleClass('active');
-      $(self).find(`#slide-${curr}`).toggleClass('active');
-      $(self).find(`[data-target="#slide-${curr}"]`).toggleClass('active');
+      $(self).find('.active').toggleClass('active')
+      $(self).find(`#slide-${curr}`).toggleClass('active')
+      $(self).find(`[data-target="#slide-${curr}"]`).toggleClass('active');     
     };
 
     let onPrev = function(event) {


### PR DESCRIPTION
heyy! A very interesting project, in the startup where I am working we are implementing the iframe provided on the page and we would like to be able to choose custom colors for the cards, background, user name color, eth icon, etc. which I decided to collaborate that could help more people that need to customize the colors of the iframe.

The changes I have made were the following:

The parameters that I will say below, are totally optional in case there is none of these parameters, the iframe will work completely normally with the default color palette (light and dark mode):

for the colors to be applied they have to be in hexadecimal code (example: # 3300ff):

- bg_color=3300ff (body && nft-section background color)
- bg_card=3300ff (nft cards background color)
- addr_color=3300ff (ethereum address color)
- asset_name_color=3300ff (nft name color)
- collection_name_color=3300ff (nft author color)
- eth_icon=1 (choose eth icon, 1 = white, 2 = black)

If my pr is accepted and it is useful, i could make the implementation of the colors for the navbar 😄